### PR TITLE
Build using setuptools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,24 @@
-build
+# general things to ignore
+build/
+dist/
+*.whl
+*.egg-info/
+*.egg
+*.py[cod]
+__pycache__/
+*.so
+*~
+
+.DS_Store
+
+# due to using tox and pytest
+.tox
+.cache
+
+Pipfile
+Pipfile.lock
+
+
 session.vim
 Makefile
 *.make

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include README.md
+include LICENSE.txt
+include setup.py
+
+include src/itaxotools/convphase/convphase.pyd

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,3 @@
 include README.md
 include LICENSE.txt
 include setup.py
-
-include src/itaxotools/convphase/convphase.pyd

--- a/premake5.lua
+++ b/premake5.lua
@@ -148,7 +148,7 @@ workspace("ConvPhase")
 
 
 	project("phase")
-		kind("SharedLib")
+		kind("StaticLib")
 		language("C++")
 		cppdialect("C++14")
 		architecture(_OPTIONS["arch"])
@@ -181,7 +181,6 @@ workspace("ConvPhase")
 			defines({"NDEBUG"})
 			optimize("Full")
 			--symbols("Off")
-
 
 
 	project("seqphase")

--- a/premake5.lua
+++ b/premake5.lua
@@ -39,6 +39,7 @@ workspace("ConvPhase")
 		allowed = {
 			{"x86", "x86/x32, 32 bit architecture"},
 			{"x86_64", "x86_64/x64, 64 bit architecture"},
+			{"arm64", "arm64, 64 bit architecture"},
 		}
 	})
 	newoption({
@@ -113,6 +114,8 @@ workspace("ConvPhase")
 			defines("HXCPP_M32")
 		filter("options:arch=x86_64")
 			defines("HXCPP_M64")
+		filter("options:arch=arm64")
+			defines("HXCPP_ARM64")
 		filter({})
 		pic("On")
 		linkoptions({})
@@ -212,6 +215,8 @@ workspace("ConvPhase")
 			table.insert(haxeBuildCmd, "-D HXCPP_M32")
 		elseif _OPTIONS["arch"] == "x86_64" then
 			table.insert(haxeBuildCmd, "-D HXCPP_M64")
+		elseif _OPTIONS["arch"] == "arm64" then
+			table.insert(haxeBuildCmd, "-D HXCPP_ARM64")
 		end
 
 		postbuildcommands({

--- a/premake5.lua
+++ b/premake5.lua
@@ -141,9 +141,17 @@ workspace("ConvPhase")
 			--symbols("Off")
 
 		if _OPTIONS["target"] then
-			postbuildcommands {
-				"{COPYFILE} $(TargetPath) " .. _OPTIONS["target"]
-			}
+			filter({"not system:windows"})
+				postbuildcommands {
+					"{COPYFILE} %{cfg.buildtarget.relpath} " .. _OPTIONS["target"]
+				}
+			filter({})
+			filter({"system:windows"})
+				postbuildcommands {
+					"{COPYFILE} $(TargetPath) " .. _OPTIONS["target"]
+				}
+			filter({})
+
 		end
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pip==23.0.1
+setuptools==67.6.1
+wheel==0.40.0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,38 @@
+"""A setuptools based setup module."""
+
+# Always prefer setuptools over distutils
+from setuptools import setup, find_namespace_packages
+from pathlib import Path
+
+# Get the long description from the README file
+here = Path(__file__).parent.resolve()
+long_description = (here / 'README.md').read_text(encoding='utf-8')
+
+
+setup(
+    name='convphase',
+    version='0.0.1',
+    description='A Python package for ConvPhase',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    package_dir={'': 'src'},
+    packages=find_namespace_packages(
+        include=('itaxotools*',),
+        where='src',
+    ),
+    python_requires='>=3.10.2, <4',
+    install_requires=[],
+    extras_require={},
+    entry_points={
+        'console_scripts': [
+            'convphase = itaxotools.convphase:run',
+        ],
+    },
+    classifiers=[
+        'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3 :: Only',
+    ],
+    include_package_data=True,
+)

--- a/setup.py
+++ b/setup.py
@@ -67,15 +67,17 @@ class BuildConvPhase(Command):
         if isinstance(arg, list):
             command = ' '.join(arg)
             tool = arg[0]
+            shell = False
         elif isinstance(arg, str):
             command = arg
             tool = arg.split(' ')[0]
+            shell = True
         else:
             raise Exception('Bad subprocess arguments')
 
         try:
             print(command)
-            result = func(arg)
+            result = func(arg, shell=shell)
             if func is check_output:
                 result = result.decode('utf-8')
                 print(result)
@@ -207,7 +209,7 @@ class BuildConvPhase(Command):
             command = f'{tool} /p:Configuration=Release'
         else:
             tool = 'make'
-            command = tool
+            command = f'{tool} config=release'
 
         self.subprocess(
             check_call, command,

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,9 @@ class BuildConvPhase(Command):
             self.macosx = True
 
         self.arch = platform.machine()
-
+        if self.arch.upper() == 'AMD64':
+            self.arch = 'x86_64'
+            
         self.find_hxcpp_includes()
         self.find_python_includes()
         self.find_python_libdirs()

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,61 @@
 """A setuptools based setup module."""
 
 # Always prefer setuptools over distutils
-from setuptools import setup, find_namespace_packages
+from setuptools import setup, find_namespace_packages, Command, msvc
+from subprocess import check_call
 from pathlib import Path
+import os
 
 # Get the long description from the README file
 here = Path(__file__).parent.resolve()
 long_description = (here / 'README.md').read_text(encoding='utf-8')
+
+
+class BuildConvPhase(Command):
+    """Custom command for building ConvPhase"""
+    description = 'compile convphase using premake'
+    user_options = []
+
+    def initialize_options(self):
+        self.name = 'itaxotools.mafftpy.mafft'
+        self.git_submodules = [
+            'phase',
+            'SeqPHASE',
+        ]
+        self.plat_name = None
+
+    def finalize_options(self):
+        self.set_undefined_options(
+            'build',
+            ('plat_name', 'plat_name'),
+        )
+
+    def run(self):
+        self.set_environ()
+        self.update_git_submodules()
+
+        print('-'*50)
+        print(self.plat_name)
+        print('-'*50)
+
+    def set_environ(self):
+        plat_name = self.plat_name
+        if plat_name.startswith('win-'):
+            plat_name = plat_name[len('win-'):]
+            env = msvc.msvc14_get_vc_env(plat_name)
+            os.environ.update(env)
+
+    def git_submodules_exist(self):
+        for submodule in self.git_submodules:
+            path = Path(submodule)
+            if not path.exists() or not any(path.iterdir()):
+                return False
+        return True
+
+    def update_git_submodules(self):
+        if Path('.gitmodules').exists() and not self.git_submodules_exist():
+            check_call(['git', 'submodule', 'update', '--init', '--recursive'])
+
 
 
 setup(
@@ -23,6 +72,9 @@ setup(
     python_requires='>=3.10.2, <4',
     install_requires=[],
     extras_require={},
+    cmdclass={
+        'build_convphase': BuildConvPhase,
+    },
     entry_points={
         'console_scripts': [
             'convphase = itaxotools.convphase:run',

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 # Always prefer setuptools over distutils
 from setuptools import setup, find_namespace_packages, Command, msvc
+from setuptools.command.build_ext import build_ext as _build_ext
 from subprocess import check_call, check_output, CalledProcessError
 from distutils import sysconfig
 from pathlib import Path
@@ -207,6 +208,14 @@ class BuildConvPhase(Command):
         )
 
 
+class build_ext(_build_ext):
+    """Overrides setuptools to build convphase by default"""
+    def run(self):
+        self.reinitialize_command('build_convphase', inplace=1)
+        self.run_command('build_convphase')
+        super().run()
+
+
 setup(
     name='convphase',
     version='0.0.1',
@@ -223,6 +232,7 @@ setup(
     extras_require={},
     cmdclass={
         'build_convphase': BuildConvPhase,
+        'build_ext': build_ext,
     },
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,17 @@ class BuildConvPhase(Command):
     """Custom command for building ConvPhase"""
     description = 'compile convphase using premake'
     user_options = [
-        ('build-lib=', 'b', "directory for compiled extension modules"),
+        ('build-lib=', 'b', 'directory for compiled extension modules'),
         (
             'inplace',
             'i',
-            "ignore build-lib and put compiled extensions into the source "
-            + "directory alongside your pure Python modules",
+            'ignore build-lib and put compiled extensions into the source '
+            + 'directory alongside your pure Python modules',
+        ),
+        (
+            'make',
+            'm',
+            'call premake without building',
         ),
     ]
 
@@ -37,6 +42,7 @@ class BuildConvPhase(Command):
         self.plat_name = None
         self.windows = False
         self.inplace = 0
+        self.make = 0
 
     def finalize_options(self):
         self.set_undefined_options(
@@ -53,7 +59,9 @@ class BuildConvPhase(Command):
         self.update_git_submodules()
         self.set_environ()
         self.premake()
-        self.build()
+
+        if not self.make:
+            self.build()
 
     def subprocess(self, func, arg, error, missing=None):
         if isinstance(arg, list):

--- a/setup.py
+++ b/setup.py
@@ -16,20 +16,31 @@ long_description = (here / 'README.md').read_text(encoding='utf-8')
 class BuildConvPhase(Command):
     """Custom command for building ConvPhase"""
     description = 'compile convphase using premake'
-    user_options = []
+    user_options = [
+        ('build-lib=', 'b', "directory for compiled extension modules"),
+        (
+            'inplace',
+            'i',
+            "ignore build-lib and put compiled extensions into the source "
+            + "directory alongside your pure Python modules",
+        ),
+    ]
 
     def initialize_options(self):
-        self.name = 'itaxotools.mafftpy.mafft'
+        self.name = 'itaxotools.convphase.convphase'
 
         self.hxcpp_includes = []
         self.python_includes = []
         self.python_libs = []
+        self.build_lib = None
         self.plat_name = None
         self.windows = False
+        self.inplace = 0
 
     def finalize_options(self):
         self.set_undefined_options(
             'build',
+            ('build_lib', 'build_lib'),
             ('plat_name', 'plat_name'),
         )
 
@@ -38,28 +49,50 @@ class BuildConvPhase(Command):
         self.find_python_libs()
 
     def run(self):
-        self.set_environ()
         self.update_git_submodules()
+        self.set_environ()
         self.premake()
         self.build()
+
+    def subprocess(self, func, arg, error, missing=None):
+        if isinstance(arg, list):
+            command = ' '.join(arg)
+            tool = arg[0]
+        elif isinstance(arg, str):
+            command = arg
+            tool = arg.split(' ')[0]
+        else:
+            raise Exception('Bad subprocess arguments')
+
+        try:
+            print(command)
+            result = func(arg)
+            if func is check_output:
+                result = result.decode('utf-8')
+                print(result)
+            return result
+        except OSError as e:
+            missing = missing or f'Couldn\'t find {tool}, is {tool} installed?'
+            raise Exception(missing) from e
+        except CalledProcessError as e:
+            raise Exception(error) from e
 
     def set_environ(self):
         plat_name = self.plat_name
         if plat_name.startswith('win-'):
+            print('Loading MSVC environment...')
             plat_name = plat_name[len('win-'):]
             env = msvc.msvc14_get_vc_env(plat_name)
             os.environ.update(env)
             self.windows = True
 
     def git_submodules_initialized(self):
-        try:
-            output = check_output(['git', 'submodule', 'status'])
-        except OSError as e:
-            raise Exception('Couldn\'t find git, is git installed?') from e
-        except CalledProcessError as e:
-            raise Exception('Couldn\'t check git submodule status') from e
+        output = self.subprocess(
+            check_output, ['git', 'submodule', 'status'],
+            'Couldn\'t check git submodule status'
+        )
 
-        submodules = output.decode('utf-8').split('\n')
+        submodules = output.split('\n')
         for submodule in submodules:
             if submodule.strip().startswith('-'):
                 return False
@@ -67,21 +100,19 @@ class BuildConvPhase(Command):
 
     def update_git_submodules(self):
         if not self.git_submodules_initialized():
-            try:
-                check_call(['git', 'submodule', 'update', '--init', '--recursive'])
-            except OSError as e:
-                raise Exception('Couldn\'t find git, is git installed?') from e
-            except CalledProcessError as e:
-                raise Exception('Couldn\'t initialize git submodules') from e
+            self.subprocess(
+                check_call, ['git', 'submodule', 'update', '--init', '--recursive'],
+                'Couldn\'t initialize git submodules'
+            )
 
     def find_hxcpp_includes(self):
-        try:
-            output = check_output(['haxelib', 'libpath', 'hxcpp'])
-        except OSError as e:
-            raise Exception('Couldn\'t find haxelib, is haxe installed?') from e
-        except CalledProcessError as e:
-            raise Exception('Couldn\'t find hxcpp libpath, is hxcpp installed? (haxelib install hxcpp)') from e
-        hxcpp = output.decode('utf-8').strip()
+        output = self.subprocess(
+            check_output, ['haxelib', 'libpath', 'hxcpp'],
+            'Couldn\'t find hxcpp libpath, is hxcpp installed? (haxelib install hxcpp)',
+            'Couldn\'t find haxelib, is haxe installed?'
+        )
+
+        hxcpp = output.strip()
         path = Path(hxcpp) / 'include'
         if not path.exists() or not any(path.iterdir()):
             raise Exception(f'Bad hxcpp include: {str(path)}')
@@ -103,38 +134,77 @@ class BuildConvPhase(Command):
         libs = Path(sys.base_exec_prefix) / 'libs'
         self.python_libs.append(libs)
 
+    def get_target_filename(self, name):
+        suffix = sysconfig.get_config_var('EXT_SUFFIX')
+        return name + suffix
+
+    def get_target_path(self):
+        parts = self.name.split('.')
+        filename = self.get_target_filename(parts[-1])
+
+        if not self.inplace:
+            build_path = Path(self.build_lib)
+            module_path = Path().joinpath(*parts[:-1])
+            package_path = build_path / module_path
+        else:
+            package = '.'.join(parts[:-1])
+            build_py = self.get_finalized_command('build_py')
+            package_dir = build_py.get_package_dir(package)
+            package_path = Path(package_dir)
+
+        package_path.mkdir(parents=True, exist_ok=True)
+        return str(Path(package_path / filename).absolute())
+
     def premake(self):
         plat_name = self.plat_name
         if self.windows:
             version = os.environ.get('VisualStudioVersion', None)
             if version == '16.0':
-                target = 'vs2019'
+                action = 'vs2019'
             elif version == '17.0':
-                target = 'vs2022'
+                action = 'vs2022'
             else:
                 raise Exception('Cannot determine Visual Studio version')
         else:
-            target = 'gmake2'
+            action = 'gmake2'
 
-        try:
-            output = check_call(['premake5', target])
-        except OSError as e:
-            raise Exception('Couldn\'t find premake5, is premake installed?') from e
-        except CalledProcessError as e:
-            raise Exception(f'premake failed for target: {target}') from e
+        # Command in string form since using lists with check_call
+        # breaks premake's argument parsing
+        command = f'premake5 {action}'
+
+        includes = self.python_includes + self.hxcpp_includes
+        if includes:
+            includes = [str(path) for path in includes]
+            includes = ';'.join(includes)
+            command += f' --includedirs=\"{includes}\"'
+
+        libs = self.python_libs
+        if libs:
+            libs = [str(path) for path in libs]
+            libs = ';'.join(libs)
+            command += f' --libdirs=\"{libs}\"'
+
+        target = self.get_target_path()
+        command += f' --target=\"{target}\"'
+
+        self.subprocess(
+            check_call, command,
+            f'premake failed for action: {action}',
+        )
 
     def build(self):
         if self.windows:
             tool = 'msbuild'
+            command = f'{tool} /p:Configuration=Release'
         else:
             tool = 'make'
+            command = tool
 
-        try:
-            output = check_call([tool])
-        except OSError as e:
-            raise Exception(f'Couldn\'t find build tool: {tool}') from e
-        except CalledProcessError as e:
-            raise Exception(f'Building with {tool} failed!') from e
+        self.subprocess(
+            check_call, command,
+            f'Building with {tool} failed!',
+            f'Couldn\'t find build tool: {tool}'
+        )
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,10 @@
 
 # Always prefer setuptools over distutils
 from setuptools import setup, find_namespace_packages, Command, msvc
-from subprocess import check_call
+from subprocess import check_call, check_output, CalledProcessError
+from distutils import sysconfig
 from pathlib import Path
+import sys
 import os
 
 # Get the long description from the README file
@@ -18,11 +20,12 @@ class BuildConvPhase(Command):
 
     def initialize_options(self):
         self.name = 'itaxotools.mafftpy.mafft'
-        self.git_submodules = [
-            'phase',
-            'SeqPHASE',
-        ]
+
+        self.hxcpp_includes = []
+        self.python_includes = []
+        self.python_libs = []
         self.plat_name = None
+        self.windows = False
 
     def finalize_options(self):
         self.set_undefined_options(
@@ -30,13 +33,15 @@ class BuildConvPhase(Command):
             ('plat_name', 'plat_name'),
         )
 
+        self.find_hxcpp_includes()
+        self.find_python_includes()
+        self.find_python_libs()
+
     def run(self):
         self.set_environ()
         self.update_git_submodules()
-
-        print('-'*50)
-        print(self.plat_name)
-        print('-'*50)
+        self.premake()
+        self.build()
 
     def set_environ(self):
         plat_name = self.plat_name
@@ -44,18 +49,92 @@ class BuildConvPhase(Command):
             plat_name = plat_name[len('win-'):]
             env = msvc.msvc14_get_vc_env(plat_name)
             os.environ.update(env)
+            self.windows = True
 
-    def git_submodules_exist(self):
-        for submodule in self.git_submodules:
-            path = Path(submodule)
-            if not path.exists() or not any(path.iterdir()):
+    def git_submodules_initialized(self):
+        try:
+            output = check_output(['git', 'submodule', 'status'])
+        except OSError as e:
+            raise Exception('Couldn\'t find git, is git installed?') from e
+        except CalledProcessError as e:
+            raise Exception('Couldn\'t check git submodule status') from e
+
+        submodules = output.decode('utf-8').split('\n')
+        for submodule in submodules:
+            if submodule.strip().startswith('-'):
                 return False
         return True
 
     def update_git_submodules(self):
-        if Path('.gitmodules').exists() and not self.git_submodules_exist():
-            check_call(['git', 'submodule', 'update', '--init', '--recursive'])
+        if not self.git_submodules_initialized():
+            try:
+                check_call(['git', 'submodule', 'update', '--init', '--recursive'])
+            except OSError as e:
+                raise Exception('Couldn\'t find git, is git installed?') from e
+            except CalledProcessError as e:
+                raise Exception('Couldn\'t initialize git submodules') from e
 
+    def find_hxcpp_includes(self):
+        try:
+            output = check_output(['haxelib', 'libpath', 'hxcpp'])
+        except OSError as e:
+            raise Exception('Couldn\'t find haxelib, is haxe installed?') from e
+        except CalledProcessError as e:
+            raise Exception('Couldn\'t find hxcpp libpath, is hxcpp installed? (haxelib install hxcpp)') from e
+        hxcpp = output.decode('utf-8').strip()
+        path = Path(hxcpp) / 'include'
+        if not path.exists() or not any(path.iterdir()):
+            raise Exception(f'Bad hxcpp include: {str(path)}')
+        self.hxcpp_includes.append(path)
+
+    def find_python_includes(self):
+        includes = sysconfig.get_python_inc()
+        self.python_includes.append(Path(includes))
+
+        if sys.exec_prefix != sys.base_exec_prefix:
+            includes = Path(sys.exec_prefix) / 'include'
+            self.python_includes.append(Path(includes))
+
+        plat_includes = sysconfig.get_python_inc(plat_specific=1)
+        if plat_includes != includes:
+            self.python_includes.append(Path(plat_includes))
+
+    def find_python_libs(self):
+        libs = Path(sys.base_exec_prefix) / 'libs'
+        self.python_libs.append(libs)
+
+    def premake(self):
+        plat_name = self.plat_name
+        if self.windows:
+            version = os.environ.get('VisualStudioVersion', None)
+            if version == '16.0':
+                target = 'vs2019'
+            elif version == '17.0':
+                target = 'vs2022'
+            else:
+                raise Exception('Cannot determine Visual Studio version')
+        else:
+            target = 'gmake2'
+
+        try:
+            output = check_call(['premake5', target])
+        except OSError as e:
+            raise Exception('Couldn\'t find premake5, is premake installed?') from e
+        except CalledProcessError as e:
+            raise Exception(f'premake failed for target: {target}') from e
+
+    def build(self):
+        if self.windows:
+            tool = 'msbuild'
+        else:
+            tool = 'make'
+
+        try:
+            output = check_call([tool])
+        except OSError as e:
+            raise Exception(f'Couldn\'t find build tool: {tool}') from e
+        except CalledProcessError as e:
+            raise Exception(f'Building with {tool} failed!') from e
 
 
 setup(

--- a/src/itaxotools/convphase/__init__.py
+++ b/src/itaxotools/convphase/__init__.py
@@ -15,7 +15,7 @@ def run():
     parser.add_argument('input', type=str, help='Path to input file')
     parser.add_argument('-o', '--output', type=str, help='Path to output file')
 
-    parser.add_argument('-n', '--number-of-iterations', type=int, default=100, help='Number of MCMC iterations ')
+    parser.add_argument('-n', '--number-of-iterations', type=int, default=100, help='Number of MCMC iterations')
     parser.add_argument('-t', '--thinning-interval', type=int, default=1, help='Thinning interval')
     parser.add_argument('-b', '--burn-in', type=int, default=100, help='Burn in')
 

--- a/src/itaxotools/convphase/__init__.py
+++ b/src/itaxotools/convphase/__init__.py
@@ -1,0 +1,50 @@
+
+"""Console entry point"""
+
+from argparse import ArgumentParser
+from pathlib import Path
+from sys import stderr
+
+from .main import main
+
+
+def run():
+
+    parser = ArgumentParser(description='Convenient Phase')
+
+    parser.add_argument('input', type=str, help='Path to input file')
+    parser.add_argument('-o', '--output', type=str, help='Path to output file')
+
+    parser.add_argument('-n', '--number-of-iterations', type=int, default=100, help='Number of MCMC iterations ')
+    parser.add_argument('-t', '--thinning-interval', type=int, default=1, help='Thinning interval')
+    parser.add_argument('-b', '--burn-in', type=int, default=100, help='Burn in')
+
+    parser.add_argument('-p', '--phase-threshold', type=float, default=0.9, help='Phase threshold (phase certainty)')
+    parser.add_argument('-q', '--allele-threshold', type=float, default=0.9, help='Allele threshold (genotype certainty)')
+
+    args = parser.parse_args()
+
+    input = args.input
+    with open(args.input) as file:
+        sequences = file.read()
+    del args.input
+
+    output = args.output
+    del args.output
+
+    print('', file=stderr)
+    print(f'Calling convphase on {input} with parameters:', file=stderr)
+    for k, v in vars(args).items():
+        print(f'> {k} = {v}', file=stderr)
+    results = main(sequences, **vars(args))
+
+    if output is None:
+        print()
+        print(results)
+        print()
+        return
+
+    with open(output, 'w') as file:
+        print(f'Writing results to {output}...', file=stderr)
+        file.write(results)
+        file.write('\n')

--- a/src/itaxotools/convphase/main.py
+++ b/src/itaxotools/convphase/main.py
@@ -1,0 +1,26 @@
+
+from .convphase import convPhase
+
+
+def main(
+    input: str,
+    number_of_iterations: int = 100,
+    thinning_interval: int = 1,
+    burn_in: int = 100,
+    phase_threshold: float = 0.9,
+    allele_threshold: float = 0.9,
+) -> str:
+
+    args = []
+
+    args.append(input)
+
+    args.append(f'-p{phase_threshold}')
+    args.append(f'-q{allele_threshold}')
+
+    args.append(str(number_of_iterations))
+    args.append(str(thinning_interval))
+    args.append(str(burn_in))
+
+    output = convPhase(*args)
+    return output


### PR DESCRIPTION
This update connects the premake solution to the setuptools machinery.

You may now install the package using pip:
```
pip install -vvv git+https://github.com/iTaxoTools/ConvPhase.git@build-setuptools
```

Also works in editable mode:
```
git clone https://github.com/iTaxoTools/ConvPhase.git
cd ConvPhase
pip install -e .
```

A custom setuptools command is used when installing that:
- Initializes Git Submodules
- Loads the MSVC environment if needed
- Detects includes and libdirs for Python and Haxe
- Creates the makefiles using premake
- Builds the project using the appropriate tool
- Copies the resulting library to its new home per setuptools standard
- Works for Windows, Linux and MacOS

This custom command can also be called without installing:
```
python setup.py build_convphase
```

To call premake without building:
```
python setup.py build_convphase --make
```

When installing, a console endpoint is also created that wraps the C++ extension and only exposes a selected subset of PHASE parameters:
```
$ convphase test\samples\homozygousIndividualsToPhase.fa

usage: convphase [-h] [-o OUTPUT] [-n NUMBER_OF_ITERATIONS] [-t THINNING_INTERVAL] [-b BURN_IN]
                 [-p PHASE_THRESHOLD] [-q ALLELE_THRESHOLD]
                 input
```

Merging this update should help us consistently build the project across platforms and include ConvPhase as a Python dependency in other projects (like the ConvPhaseGui).
